### PR TITLE
Make the SU solution switchable

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -249,9 +249,21 @@ PRODUCT_PACKAGES += \
     procrank
 
 # Conditionally build in su
-ifeq ($(WITH_SU),true)
+ifeq ($(USE_SU),true)
 PRODUCT_PACKAGES += \
     su
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.sys.root_access=3
+
+else
+
+# Conditionally copy Magisk zip
+PRODUCT_COPY_FILES += \
+    vendor/beanstalk/prebuilt/common/magisk.zip:system/addon.d/magisk.zip
+
+# Magisk Manager
+PRODUCT_PACKAGES += \
+    MagiskManager
 endif
 
 # OMS MASQUERADE
@@ -261,14 +273,6 @@ PRODUCT_PACKAGES += \
 # OMS Verified
 PRODUCT_PROPERTY_OVERRIDES := \
     ro.substratum.verified=true
-
-# Copy Magisk zip
-PRODUCT_COPY_FILES += \
-    vendor/beanstalk/prebuilt/common/magisk.zip:system/addon.d/magisk.zip
-
-# Magisk Manager
-PRODUCT_PACKAGES += \
-    MagiskManager
 
 DEVICE_PACKAGE_OVERLAYS += vendor/beanstalk/overlay/common
 

--- a/prebuilt/Android.mk
+++ b/prebuilt/Android.mk
@@ -17,6 +17,11 @@ LOCAL_PATH := $(call my-dir)
 #
 # Prebuilt APKs
 #
+
+ifneq ($(USE_SU),true)
+
+$(file > $(ANDROID_BUILD_TOP)/out/target/common/with_su,false)
+
 include $(CLEAR_VARS)
 LOCAL_MODULE := MagiskManager
 LOCAL_MODULE_OWNER := beanstalk
@@ -26,3 +31,9 @@ LOCAL_MODULE_SUFFIX := .apk
 LOCAL_MODULE_CLASS := APPS
 LOCAL_CERTIFICATE := PRESIGNED
 include $(BUILD_PREBUILT)
+
+else
+
+$(file > $(ANDROID_BUILD_TOP)/out/target/common/with_su,true)
+
+endif


### PR DESCRIPTION
Currently Magisk is the default SU solution and no other SU solution can be selected. Thanks to this commit and my commit in platform_build USE_SU := true in the device.mk can disable Magisk and enable the LineageSU solution some people prefer. This way Magisk stays the default SU solution and will only be replaced if USE_SU will be set to true.